### PR TITLE
Show we can have multiple radar views, if necessary

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 A Tech Radar for Redgate. This helps us by recognizing the technology that:
 * We use
-* We're trialling and building experience
+* We're trialing and building experience
 * We're excited about!
 * We used to use and use no longer.
 

--- a/README.md
+++ b/README.md
@@ -10,6 +10,8 @@ We use [Thoughtworks Tech Radar](https://radar.thoughtworks.com/) to generate ou
 
 You can see the [latest version online](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fmaster%2Fradar.csv).
 
+We can have [multiple radars for different contexts](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fmaster%2Fsmaller-context.csv) if they are useful. Maybe a separate radar for desktop and server-bound tools would be useful alongside a global overview?
+
 Please note this is public!
 
 

--- a/smaller-context.csv
+++ b/smaller-context.csv
@@ -1,12 +1,11 @@
 name,ring,quadrant,isNew,description
 Daily standups,adopt,practices,true,Having a daily standup each day helps us prepare to have the best possible day
 Pairing,adopt,practices,true,Pairing helps collaboration and knowledge transfer within the team.
-Mobbing,assess,practices,true,We've been experimenting with mob programming
+Mobbing,assess,practices,false,We've been experimenting with mob programming
 .NET Core,adopt,languages and frameworks,true,Microsoft has delivered a cross-platform future. New applications should be built with .NET Core by default
 .NET Framework,hold,languages and frameworks,true,With the advent of .NET CORE we should not use .NET Framework to build any more products
-C#,adopt,languages and frameworks,true,We build our software using C#
+C#,adopt,languages and frameworks,false,We build our software using C#
 JavaScript,hold,languages and frameworks,true,Whilst JavaScript is the lingua franca of the web we prefer TypeScript for the benefits of type safety and IDE integrations
 TypeScript,adopt,languages and frameworks,true,TypeScript provides an advanced type system on top of JavaScript. We prefer this for compile errors rather than runtime.
 Moq,adopt,libraries,true,Moq is our default mocking framework and preferred to alternatives such as Rhino Mocks
-Rhino Mocks,hold,libraries,true,Moq is our preferred framework
 Balsamiq,adopt,services,true,Balsamiq gives us the ability to create quick low-fidelity wireframes to describe workflows

--- a/smaller-context.csv
+++ b/smaller-context.csv
@@ -1,0 +1,12 @@
+name,ring,quadrant,isNew,description
+Daily standups,adopt,practices,true,Having a daily standup each day helps us prepare to have the best possible day
+Pairing,adopt,practices,true,Pairing helps collaboration and knowledge transfer within the team.
+Mobbing,assess,practices,true,We've been experimenting with mob programming
+.NET Core,adopt,languages and frameworks,true,Microsoft has delivered a cross-platform future. New applications should be built with .NET Core by default
+.NET Framework,hold,languages and frameworks,true,With the advent of .NET CORE we should not use .NET Framework to build any more products
+C#,adopt,languages and frameworks,true,We build our software using C#
+JavaScript,hold,languages and frameworks,true,Whilst JavaScript is the lingua franca of the web we prefer TypeScript for the benefits of type safety and IDE integrations
+TypeScript,adopt,languages and frameworks,true,TypeScript provides an advanced type system on top of JavaScript. We prefer this for compile errors rather than runtime.
+Moq,adopt,libraries,true,Moq is our default mocking framework and preferred to alternatives such as Rhino Mocks
+Rhino Mocks,hold,libraries,true,Moq is our preferred framework
+Balsamiq,adopt,services,true,Balsamiq gives us the ability to create quick low-fidelity wireframes to describe workflows


### PR DESCRIPTION
It's pretty easy to have multiple radars, if we want different views for different contexts . For instance, if the divisional-level radar is incredibly noisy we may want split radars for desktop and server tools.

I thought I'd throw this in as an example, just to show how easy it is.

We'd need to maintain them separately, but they're only `.csv` files.

The new link in the README is setup for if/when this is merged to `master`, so doesn't currently work. [Here is an equivilant link that works for this branch](https://radar.thoughtworks.com/?sheetId=https://raw.githubusercontent.com/red-gate/Tech-Radar/per-team-radar/smaller-context.csv).