### PR TITLE
Set all entries to new

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -11,11 +11,11 @@ TypeScript,adopt,languages and frameworks,true,TypeScript provides an advanced t
 Moq,adopt,languages and frameworks,true,Moq is our default mocking framework and preferred to alternatives such as Rhino Mocks
 Rhino Mocks,endure,languages and frameworks,true,Moq is our preferred framework
 Balsamiq,adopt,tools,true,Balsamiq gives us the ability to create quick low-fidelity wireframes to describe workflows
-Git,adopt,tools,false,Git is our defacto VCS.
+Git,adopt,tools,true,Git is our defacto VCS.
 OneDrive,adopt,tools,true,"OneDrive is our default choice for storing Office documents to share within the organization. In the last three years, Microsoft have done a lot of work on OneDrive and the associated sync clients and have closed the gap on their competitors. The sync client is very stable and doesn’t contain the restrictions that it did before."
 Raygun,explore,tools,true,Raygun allows loosely-coupled error reporting to a web endpoint.
 Google Drive,retire,tools,true,"We don’t have corporate Google accounts and it doesn’t make sense to subscribe to both GSuite and Office 365, both for cost reasons and from an information management point of view. The fact that we don’t have corporate accounts means data can’t be removed from Google accounts when someone leaves the company (as we don’t own the account), so we shouldn’t be storing any personal information (such as customer data) in Google Drive."
-SmartAssembly,retire,tools,false,SmartAssembly obfuscation and error reporting becomes tightly-coupled to products and slows down builds.
+SmartAssembly,retire,tools,true,SmartAssembly obfuscation and error reporting becomes tightly-coupled to products and slows down builds.
 Windows,adopt,platforms,true,"Our default supported operating system is Windows. If Microsoft continues to support this as part of their default support package we continue to support running our applications on that OS. See https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet"
 Chrome,adopt,platforms,true,"Chrome is Google's evergreen browser. We support it by default"
 Firefox,adopt,platforms,true,"Firefox is Mozilla's evergreen browser. We support it by default"

--- a/smaller-context.csv
+++ b/smaller-context.csv
@@ -9,9 +9,9 @@ C#,adopt,languages and frameworks,true,We build our software using C#
 JavaScript,endure,languages and frameworks,true,Whilst JavaScript is the lingua franca of the web we prefer TypeScript for the benefits of type safety and IDE integrations
 Moq,adopt,languages and frameworks,true,Moq is our default mocking framework and preferred to alternatives such as Rhino Mocks
 Rhino Mocks,endure,languages and frameworks,true,Moq is our preferred framework
-Git,adopt,tools,false,Git is our defacto VCS.
+Git,adopt,tools,true,Git is our defacto VCS.
 OneDrive,adopt,tools,true,"OneDrive is our default choice for storing Office documents to share within the organization. In the last three years, Microsoft have done a lot of work on OneDrive and the associated sync clients and have closed the gap on their competitors. The sync client is very stable and doesn’t contain the restrictions that it did before."
 Raygun,explore,tools,true,Raygun allows loosely-coupled error reporting to a web endpoint.
 Google Drive,retire,tools,true,"We don’t have corporate Google accounts and it doesn’t make sense to subscribe to both GSuite and Office 365, both for cost reasons and from an information management point of view. The fact that we don’t have corporate accounts means data can’t be removed from Google accounts when someone leaves the company (as we don’t own the account), so we shouldn’t be storing any personal information (such as customer data) in Google Drive."
-SmartAssembly,retire,tools,false,SmartAssembly obfuscation and error reporting becomes tightly-coupled to products and slows down builds.
+SmartAssembly,retire,tools,true,SmartAssembly obfuscation and error reporting becomes tightly-coupled to products and slows down builds.
 Windows,adopt,platforms,true,"Our default supported operating system is Windows. If Microsoft continues to support this as part of their default support package we continue to support running our applications on that OS. See https://support.microsoft.com/en-us/help/13853/windows-lifecycle-fact-sheet"


### PR DESCRIPTION
As agreed with @fffej : Let's make all tech radar entries "isNew:true" for v1.

This allows consistent use of the age of entries in future, and keeps things a little tidier.