### PR TITLE
Add SonarQube to tech radar

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -33,3 +33,4 @@ NSubsitute,adopt,languages and frameworks,true,"NSubstitute is our default mocki
 Moq,endure,languages and frameworks,true,"Moq is a great framework for mocking, but we prefer NSubstitute's simplicity. We see no benefit in having a common mocking framework across solutions"
 Fakes,explore,techniques,true,"We've experimented using Fakes (see https://github.com/testdouble/contributing-tests/wiki/Test-Double for definition) in the Redgate Usage Client - fakes used in the test can reduce the amount of mocking is required and can make the tests simpler"
 Rhino Mocks,retire,languages and frameworks,true,"Rhino Mocks is no longer actively maintained, nor does it support .NET Core / .NET Standard"
+SonarQube,adopt,tools,true,"Sonarqube provides automated code review, highlighting quality issues in changing code. This feedback is best surfaced through automated PR comments."


### PR DESCRIPTION
Resolves #30 - [adds SonarQube to _Tools/Adopt_.](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fmaster%2Fradar.csv)

I'm not sure of any committed alternatives, so I'm not adding them.