### PR TITLE
Added an entry for Adopting Pester for PowerShell tests

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -18,6 +18,7 @@ Autofac,adopt,languages and frameworks,true,"Autofac is an Inversion of Control 
 Ninject,endure,languages and frameworks,true,"Ninject is a dependency injector for .NET applications. However, Autofac is our preferred IoC container."
 NUnit 2,endure,languages and frameworks,true,"NUnit is our default framework for writing unit and integration tests. NUnit 2 is working well in most projects that use it, but consider upgrading to NUnit 3 for newer features."
 NUnit 3,adopt,languages and frameworks,true,"NUnit is our default framework for writing unit and integration tests. We use NUnit 3 by default for new projects."
+Pester,adopt,languages and frameworks,true,"Pester is our default framework for writing tests in PowerShell. We use Pester by default for new PowerShell tests."
 Balsamiq,adopt,tools,true,Balsamiq gives us the ability to create quick low-fidelity wireframes to describe workflows
 Git,adopt,tools,true,Git is our defacto VCS.
 OneDrive,adopt,tools,true,"OneDrive is our default choice for storing Office documents to share within the organization. In the last three years, Microsoft have done a lot of work on OneDrive and the associated sync clients and have closed the gap on their competitors. The sync client is very stable and doesn’t contain the restrictions that it did before."


### PR DESCRIPTION
Addresses the decision in #62 about adopting Pester as the testing framework of choice in PowerShell.