### PR TITLE
Clarify expectations around explore items

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ The rings in the quadrants help us choose the technology. The rings are:
 
 * *Adopt* - This is the technology you should be choosing to solve a problem. Everything in here forms our default set of technology choices (for example, C#), and will already be in-use with at least one Redgate team.
 
-* *Explore* - This has potential and is worth experimenting with in 10% time or running a trial on your team. Putting something in Explore is a commitment to explore it between now and the next issue of the Tech Radar.
+* *Explore* - This has potential and is worth experimenting with in 10% time or running a trial on your team. Putting something in Explore is a commitment to explore it between now and the next issue of the Tech Radar. The description of any Explore item should state who is committed to exploring it.
 
 * *Endure* - This is no longer how we do things. It is OK for this to be used in Product Development, but don't add more of it and migrate off it wherever possible.
 


### PR DESCRIPTION
Suggested this to @fffej to help accountability/review of _Explore_ items:

* Anything in _Explore_ is something we're committed to exploring
* That must (?) mean someone has made a commitment
* Putting who is committed in the Tech-Radar will allow us to check in on their explorations while reviewing progress, and give interested parties a point of contact if they want to get involved.