### PR TITLE
Move Mixpanel from "Retire" to "Endure"

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -42,7 +42,7 @@ Wix 2,retire,tools,true,"Windows Installer XML Toolset 2 (WiX), is a free softwa
 Inno Setup,endure,tools,true,"SQL Backup uses divergent installer technology."
 RedGate.Usage.Client,adopt,tools,true,"Redgate's standard tool for Product and Feature usage reporting"
 AppInsights,adopt,tools,true,"Microsoft's platform for data analysis"
-MixPanel,endure,tools,true,"Tool for presenting analytic data. Now superseded by AppInsights."
+MixPanel,endure,tools,true,"Tool for presenting analytic data. Now superseded by AppInsights. We will review whether to retire this when Application Insights has a configurable retention period."
 Google Analytics,retire,tools,true,"Tool for presenting analytic data. Now superseded by AppInsights."
 SonarQube,adopt,tools,true,"Sonarqube provides automated code review, highlighting quality issues in changing code. This feedback is best surfaced through automated PR comments."
 RedGate.Build,adopt,tools,true,"Redgate's standardised, scripted infrastructure for building products. Based on <a href='https://github.com/red-gate/build-script-template'>build-script-templates</a>."

--- a/radar.csv
+++ b/radar.csv
@@ -42,7 +42,7 @@ Wix 2,retire,tools,true,"Windows Installer XML Toolset 2 (WiX), is a free softwa
 Inno Setup,endure,tools,true,"SQL Backup uses divergent installer technology."
 RedGate.Usage.Client,adopt,tools,true,"Redgate's standard tool for Product and Feature usage reporting"
 AppInsights,adopt,tools,true,"Microsoft's platform for data analysis"
-MixPanel,retire,tools,true,"Tool for presenting analytic data. Now superseded by AppInsights."
+MixPanel,endure,tools,true,"Tool for presenting analytic data. Now superseded by AppInsights."
 Google Analytics,retire,tools,true,"Tool for presenting analytic data. Now superseded by AppInsights."
 SonarQube,adopt,tools,true,"Sonarqube provides automated code review, highlighting quality issues in changing code. This feedback is best surfaced through automated PR comments."
 RedGate.Build,adopt,tools,true,"Redgate's standardised, scripted infrastructure for building products. Based on <a href='https://github.com/red-gate/build-script-template'>build-script-templates</a>."


### PR DESCRIPTION
Move MixPanel from "Retire" to "Endure" as I believe we're encouraged to move across to AppInsights but without any real urgency. If this is not the case however, please let me know.