### PR TITLE
Remove Fody - this has been retired

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -47,7 +47,6 @@ RedGate.Build,adopt,tools,true,"Redgate's standardised, scripted infrastructure 
 Custom build scripts,endure,tools,true,"Builds scripts that diverge from RedGate.Build. These were useful when first made, but we should move to sandard RedGate.Build when possible."
 Build magic,retire,tools,true,"Legacy build tooling, now to be deprecated in favour of RedGate.Build."
 IL weaving,retire,tools,true,"Byte weaving magic is not desirable as it adds compile time complexity that is often not visible to developers. Please note that this does not incorporate static linker tools such as ILMerge as they can still be useful to make some components more reusable by internalising a subset of their dependencies."
-Fody,retire,tools,true,"Tool for IL weaving. No longer endorsed."
 Vagrant,adopt,tools,true,"Vagrant is an open-source software product for building and maintaining portable virtual software development environments. We use Vagrant with Puppet to provision test environments and internal infrastructure."
 Puppet,adopt,tools,true,"Puppet is an open-source software configuration management tool. We use Vagrant with Puppet to provision test environments and internal infrastructure."
 DevCloud,adopt,tools,true,"DevCloud is an internal platform for hosting short-lived virtual machines."


### PR DESCRIPTION
Since Fody has [successfully been retired](https://codesearch.red-gate.com/?q=fody&i=nope&files=&repos=), I guess we can/should remove it from the radar?

[Preview](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fremove-fody%2Fradar.csv)