### PR TITLE
add CommandLineParser and RedGate.Legacy.CommandLine to libs radar

### DIFF
--- a/radar_libraries.csv
+++ b/radar_libraries.csv
@@ -8,6 +8,6 @@ name,ring,quadrant,isNew,description
 "jscookie",adopt,NPM Packages,true,"<a href='https://github.com/js-cookie/js-cookie'>Jscookie</a> is a lightweight JavaScript API for handling browser cookies."
 "fetch",adopt,NPM Packages,true,"<a href='https://github.com/github/fetch'>Fetch</a> enables use of the <a href='https://fetch.spec.whatwg.org/'>fetch standard</a> for request/response inside a web browser."
 "axios",endure,NPM Packages,true,"<a href='https://github.com/axios/axios'>Axios</a> is a promise-based HTTP client. We only use this when there is a requirement to support IE9/10."
-"An placeholder",explore,Public NuGet,true,"An placeholder so we have 4 quadrants"
-"An placeholder",explore,Redgate NuGet,true,"An placeholder so we have 4 quadrants"
+"CommandLineParser",explore,Public NuGet,true,"CommandLineParser is a more modern commandline parser, which makes it easy to split a commandline up into multiple 'verbs'. Currently being explored by Team Orca."
+"RedGate.Legacy.CommandLine",endure,Redgate NuGet,true,"RedGate.Legacy.CommandLine is the old commandline parsing logic split out of Shared Utils. It's still used by a few products, but better libraries should be used for new development"
 "An placeholder",explore,other,true,"An placeholder so we have 4 quadrants"


### PR DESCRIPTION
Resolves https://github.com/red-gate/Tech-Radar/issues/225

I've just put in the endure/explore entries for now, since after the discussion I wasn't sure that anything in particular should go into Adopt just yet. If/when we revisit this we'll want to look over the issue comments again (and in particular the research that @adrianbanks did)

- [x] Are you happy for the content of this change to be publicly visible?
- [x] Are all new or updated entries marked as `isNew` = `true`?
- [x] Does `radar_libraries.csv` render correctly when viewed on Github?
- [x] Does the [updated tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fadd-cl-parser-libs%2Fradar_libraries.csv) display as you expect?