### PR TITLE
Adopt PowerShell Core 6 for internal automation

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -96,7 +96,7 @@ Physical whiteboards,adopt,tools,false,"Some teams use physical whiteboards for 
 "RedGate.Legacy.*",endure,languages and frameworks,false,"We have a collection of old technologies in the 'RedGate.Legacy' packages, as the name suggests these are old and should not be adopted. But moving away from them can be expensive so we don't think its worth the cost."
 "Dogfooding",adopt,techniques,false,"As a general principle we should use our own tools to solve problems. This process is known as <a href='https://en.wikipedia.org/wiki/Eating_your_own_dog_food'>dog-fooding</a>. We should do this even if we feel our products don't solve our own problems perfectly because doing so is the best way to learn how to improve our products."
 "Java",endure,languages and frameworks,false,"Typically we don't use Java, but we will when necessary. Examples include the SQL Change Automation plugins for TeamCity, Bamboo and Jenkins."
-"PowerShell Core 6",adopt,languages and frameworks,false,"For internal automation we use PowerShell Core 6."
+"PowerShell Core 6",adopt,languages and frameworks,true,"For internal automation we use PowerShell Core 6."
 "PowerShell 3+","adopt",platforms,false,"When we are writing cmdlets for external use we target PowerShell 3."
 "JSON",adopt,tools,false,"For storing user information, such as settings we want to use a textual format. The choice boils down to JSON or XML. We prefer JSON because it's less verbose."
 "XML",endure,tools,false,"For storing user information we used to use XML. We'll continue to use that, but avoid it in the future because it's very verbose. We perceive the cost of migration away to be high enough for this to be Endure, rather than Retire."

--- a/radar.csv
+++ b/radar.csv
@@ -96,7 +96,7 @@ Physical whiteboards,adopt,tools,false,"Some teams use physical whiteboards for 
 "RedGate.Legacy.*",endure,languages and frameworks,false,"We have a collection of old technologies in the 'RedGate.Legacy' packages, as the name suggests these are old and should not be adopted. But moving away from them can be expensive so we don't think its worth the cost."
 "Dogfooding",adopt,techniques,false,"As a general principle we should use our own tools to solve problems. This process is known as <a href='https://en.wikipedia.org/wiki/Eating_your_own_dog_food'>dog-fooding</a>. We should do this even if we feel our products don't solve our own problems perfectly because doing so is the best way to learn how to improve our products."
 "Java",endure,languages and frameworks,false,"Typically we don't use Java, but we will when necessary. Examples include the SQL Change Automation plugins for TeamCity, Bamboo and Jenkins."
-"PowerShell 5",adopt,languages and frameworks,false,"For internal automation we use PowerShell 5."
+"PowerShell Core 6",adopt,languages and frameworks,false,"For internal automation we use PowerShell Core 6."
 "PowerShell 3+","adopt",platforms,false,"When we are writing cmdlets for external use we target PowerShell 3."
 "JSON",adopt,tools,false,"For storing user information, such as settings we want to use a textual format. The choice boils down to JSON or XML. We prefer JSON because it's less verbose."
 "XML",endure,tools,false,"For storing user information we used to use XML. We'll continue to use that, but avoid it in the future because it's very verbose. We perceive the cost of migration away to be high enough for this to be Endure, rather than Retire."


### PR DESCRIPTION
Adopt PowerShell Core 6 for internal automation.
Bump from PS 5.

Slack discussion: https://redgate.slack.com/archives/C099Y4DH9/p1554716506052500
It should be installed on all TC agents already: https://redgate.slack.com/archives/C099Y4DH9/p1554715267049900

- [x] Are you happy for the content of this change to be publicly visible?
- [x] Are all new or updated entries marked as `isNew` = `true`?
- [x] Does `radar.csv` render correctly when viewed on Github?
- [x] Does the [updated tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fpowershell-6%2Fradar.csv) display as you expect?