### PR TITLE
Add Dapper to libraries tech radar

### DIFF
--- a/radar_libraries.csv
+++ b/radar_libraries.csv
@@ -11,3 +11,4 @@ name,ring,quadrant,isNew,description
 "CommandLineParser",explore,Public NuGet,true,"CommandLineParser is a more modern commandline parser, which makes it easy to split a commandline up into multiple 'verbs'. Currently being explored by Team Orca."
 "RedGate.Legacy.CommandLine",endure,Redgate NuGet,true,"RedGate.Legacy.CommandLine is the old commandline parsing logic split out of Shared Utils. It's still used by a few products, but better libraries should be used for new development"
 "An placeholder",explore,other,true,"An placeholder so we have 4 quadrants"
+"Dapper",adopt,Public NuGet,true,"<a href='https://github.com/StackExchange/Dapper'>Dapper</a> is a .Net object mapper that extends IDbConnection. It has no database-specific implementation details."


### PR DESCRIPTION
- [x] Are you happy for the content of this change to be publicly visible?
- [x] Are all new or updated entries marked as `isNew` = `true`?
- [x] Does `radar_libraries.csv` render correctly when viewed on Github?
- [x] Does the [updated tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fexplore-dapper%2Fradar_libraries.csv) display as you expect?

@stanislavHamara brought Dapper to my attention as something that's used in Foundry and should be on the Tech Radar.

Looks like it's being used in SQL Clone and SQL Monitor (based on a Github search), so I think it can go straight into _Adopt_ (despite my branch name...).