### PR TITLE
Explore Hangfire (library)

### DIFF
--- a/radar_libraries.csv
+++ b/radar_libraries.csv
@@ -12,3 +12,4 @@ name,ring,quadrant,isNew,description
 "RedGate.Legacy.CommandLine",endure,Redgate NuGet,true,"RedGate.Legacy.CommandLine is the old commandline parsing logic split out of Shared Utils. It's still used by a few products, but better libraries should be used for new development"
 "An placeholder",explore,other,true,"An placeholder so we have 4 quadrants"
 "Dapper",adopt,Public NuGet,true,"<a href='https://github.com/StackExchange/Dapper'>Dapper</a> is a .Net object mapper that extends IDbConnection. It has no database-specific implementation details."
+"Hangfire",explore,Public NuGet,true,"<a href='https://www.hangfire.io/'>Hangfire</a> is a library to perform background processing in .NET and .NET Core applications."


### PR DESCRIPTION
More context [here](https://github.com/red-gate/ArchitectureDecisions/blob/master/text/SQL%20Data%20Catalog/2019-07-03-classification-snapshots.md#scheduling).

### Relates to:
- https://github.com/red-gate/ArchitectureDecisions/pull/42
- https://github.com/red-gate/SqlDataCatalog/issues/1907

### Checks

- [x] Are you happy for the content of this change to be publicly visible?
- [x] Are all new or updated entries marked as `isNew` = `true`?
- [x] Do `radar.csv` and `radar_libraries` render correctly when viewed on Github?
~- [ ] Does the updated [tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fexplore-hangfire%2Fradar.csv) display as you expect?~
- [x] Does the updated [libraries tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fexplore-hangfire%2Fradar_libraries.csv) display as you expect?
