### PR TITLE
Remove SonarQube

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -14,7 +14,6 @@ SmartAssembly,retire,tools,false,"SmartAssembly obfuscation, error and usage rep
 Fakes,explore,techniques,false,"We've experimented using <a href='https://github.com/testdouble/contributing-tests/wiki/Test-Double'>Fakes</a> in the Redgate Usage Client - fakes used in the test can reduce the amount of mocking is required and can make the tests simpler."
 Wix 3,adopt,tools,false,"Windows Installer XML Toolset 3 (WiX), is a free software toolset that builds Windows Installer packages from XML. We only use Wix v3."
 AppInsights,adopt,tools,false,"Microsoft's platform for data analysis."
-SonarQube,adopt,tools,false,"Sonarqube provides automated code review, highlighting quality issues in changing code. This feedback is best surfaced through automated PR comments."
 RedGate.Build,adopt,tools,false,"Redgate's standardised, scripted infrastructure for building products. Based on <a href='https://github.com/red-gate/build-script-template'>build-script-templates</a>."
 Custom build scripts,endure,tools,false,"Builds scripts that diverge from RedGate.Build. These were useful when first made, but we should move to sandard RedGate.Build when possible."
 Build magic,retire,tools,false,"Legacy build tooling, now to be deprecated in favour of RedGate.Build."


### PR DESCRIPTION
It's decommissioned as of 16/10/2020. Few people were getting value from it.

- [x] Are you happy for the content of this change to be publicly visible?
- [x] Are all new or updated entries marked as `isNew` = `true`?
- [x] Do `radar.csv` and `radar_libraries` render correctly when viewed on Github?
- [x] Does the updated [tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fremove-sonarqube%2Fradar.csv) display as you expect?
- [x] Does the updated [libraries tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fremove-sonarqube%2Fradar_libraries.csv) display as you expect?
