### PR TITLE
Add .NET 6

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,7 @@ We're following Thoughtworks approach. For discussion on the quadrants, please s
 ## What isn’t on the Tech Radar?
 We only use the Tech Radar to capture decisions relevant to our growth products (those that we are investing in for the future). We don’t use the Tech Radar to capture historical decisions that are no longer relevant. For example, we’d prefer to say the technology we use going forward rather than listing all failed attempts in the past.
 
-We don't include libraries on the radar. For example, it's of negligible benefit to have a standardized library for dealing with date/time or for retrieving from a URL. However, it is beneficial to standardize libraries for sharing information between services. For example, if we produce a CSV file and two libraries have different escaping conventions; that might be a problem (obviously you'd hope the spec would cover it!). Similarly, if the choice of a library makes adoption of a recommend item harder then we'll try and signpost that (for example using `Rhino.Mocks` blocks moving to `.NET 5`). We'll capture these libraries as recommendations on the internal wiki.
+We don't include libraries on the radar. For example, it's of negligible benefit to have a standardized library for dealing with date/time or for retrieving from a URL. However, it is beneficial to standardize libraries for sharing information between services. For example, if we produce a CSV file and two libraries have different escaping conventions; that might be a problem (obviously you'd hope the spec would cover it!). Similarly, if the choice of a library makes adoption of a recommend item harder then we'll try and signpost that (for example using `Rhino.Mocks` blocks moving to `.NET 6`). We'll capture these libraries as recommendations on the internal wiki.
 
 Examples of things that probably SHOULD NOT be on the tech radar
 * RavenDB – it’s not a choice anyone is going to hit in the future
@@ -35,7 +35,7 @@ Examples of things that probably SHOULD NOT be on the tech radar
 * Agile techniques – again, we don’t believe in one correct way and capturing a list of techniques that do/do not work isn’t worth it
 
 Examples of things that probably SHOULD be on the tech radar
-* .NET 5 (makes our products more aligned)
+* .NET 6 (makes our products more aligned)
 * ASP.NET Core (specific version)
 * Platform technologies (it’s what we should be aligning towards)
 * More opinionated UI technology (React)

--- a/radar.csv
+++ b/radar.csv
@@ -5,6 +5,7 @@
 "Java",trial,"Languages and Frameworks",true,"Redgate purchased Flyway, written in <a href='https://www.oracle.com/java/'>Java</a>. Java is a plausible choice for new products (due to its rich ecosystem), but we default to C#."
 "Bash",adopt,"Languages and Frameworks",true,"<a href='https://www.gnu.org/software/bash/'>Bash</a> is our default choice for scripting internal tools. Everyone should be familiar with the Bash toolkit."
 "PowerShell",hold,"Languages and Frameworks",true,"Don't use PowerShell for new projects - prefer Bash."
+".NET 6",adopt,"Languages and Frameworks",true,"<a href='https://dotnet.microsoft.com/'>.NET 6</a> is in Long Term Support (LTS). It is cross-platform and a great choice for desktop, web and cloud-based applications."
 ".NET 5",adopt,"Languages and Frameworks",true,"<a href='https://dotnet.microsoft.com/'>.NET 5</a> is now cross-platform and a great choice for desktop, web and cloud-based applications."
 ".NET Core",hold,"Languages and Frameworks",true,"Don't use .NET Core - we've moved on to .NET 5."
 "ASP.NET Core",adopt,"Languages and Frameworks",true,"<a href='https://dotnet.microsoft.com/apps/aspnet'>ASP.NET</a>."

--- a/radar.csv
+++ b/radar.csv
@@ -6,8 +6,6 @@
 "Bash",adopt,"Languages and Frameworks",true,"<a href='https://www.gnu.org/software/bash/'>Bash</a> is our default choice for scripting internal tools. Everyone should be familiar with the Bash toolkit."
 "PowerShell",hold,"Languages and Frameworks",true,"Don't use PowerShell for new projects - prefer Bash."
 ".NET 6",adopt,"Languages and Frameworks",true,"<a href='https://dotnet.microsoft.com/'>.NET 6</a> is in Long Term Support (LTS). It is cross-platform and a great choice for desktop, web and cloud-based applications."
-".NET 5",adopt,"Languages and Frameworks",true,"<a href='https://dotnet.microsoft.com/'>.NET 5</a> is now cross-platform and a great choice for desktop, web and cloud-based applications."
-".NET Core",hold,"Languages and Frameworks",true,"Don't use .NET Core - we've moved on to .NET 5."
 "ASP.NET Core",adopt,"Languages and Frameworks",true,"<a href='https://dotnet.microsoft.com/apps/aspnet'>ASP.NET</a>."
 "React",adopt,"Languages and Frameworks",true,"<a href='https://reactjs.org/'>React</a> makes it painless to create interactive UIs."
 "Electron",adopt,"Platforms",true,"Electron has proved itself for developing web-based desktop products. It's our default choice for new desktop-based applications."


### PR DESCRIPTION
 - Adds .NET 6 to Teach-Radar (following the conversation in [slack](https://redgate.slack.com/archives/C02L5EQVBC1/p1635828241009100)).  
 - Removes `.NET 5` and `.NET Core` from Tech-Radar. Considering the [policy](https://info.red-gate.com/pages/viewpage.action?spaceKey=PD&title=.NET+Version ) which states that `Products SHOULD use the latest LTS version of .NET` which links to the [.NET support policy](https://dotnet.microsoft.com/platform/support/policy), end of support for `.NET 5` and `.NET Core 3.1` is May and Dec 2022 respectively.
***
- [x] Are you happy for the content of this change to be publicly visible?
- [x] Are all new or updated entries marked as `isNew` = `true`?
- [x] Does `radar.csv` render correctly when viewed on Github?
- [x] Does the updated [tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fdotnet-6%2Fradar.csv) display as you expect?

