### PR TITLE
Remove raygun from hold

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -23,7 +23,6 @@
 "Redgate.Build",hold,"Tools",true,"Redgate.Build is our own PowerShell based build scripts. Over time it's become complicated and we wouldn't recommend it for new projects."
 "Terraform",adopt,"Tools",true,"Used for automating infrastructure provisioning."
 "Application Insights",adopt,"Tools",true,"All applications should use Application Insights as the default developer telemetry platform (incl. feature usage and error reporting)."
-"Raygun",hold,"Tools",true,"Deprecated in favour of Application Insights"
 "Flyway",adopt,"Tools",true,"Our default tool for migrating database schemas."
 "WSL 2",adopt,"Tools",true,"Windows Subsystem for Linux should be installed on every development machine"
 "SignalR",adopt,"Tools",true,"<a href='https://docs.microsoft.com/en-us/aspnet/core/signalr/introduction?view=aspnetcore-5.0'>SignalR</a> is our default choice for push-functionality."


### PR DESCRIPTION
I think we have completely removed Raygun and moved to Appinsights now?

- [x] Are you happy for the content of this change to be publicly visible?
- [x] Are all new or updated entries marked as `isNew` = `true`?
- [x] Does `radar.csv` render correctly when viewed on Github?
- [x] Does the updated [tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fremove-raygun%2Fradar.csv) display as you expect?
