### PR TITLE
Add dependabot and renovate

### DIFF
--- a/radar.csv
+++ b/radar.csv
@@ -48,6 +48,8 @@ name,ring,quadrant,isNew,description
 "Feature Flagging vendors (Launch Darkly?)",assess,"Tools",true,"If your usage of feature flagging becomes sufficiently complicated then it's time to investigate third-party vendors."
 "Virtualbox based Vagrant boxes",hold,"Tools",true,"Use Docker instead where possible. UI and manual testing may still use Virtualbox."
 "Flux 2",trial,"Tools",true,"<a href='https://fluxcd.io/'>Flux</a> is an implementation of GitOps for Kubernetes, currently being trialled for Platform Hosted. It makes a cluster look like a git repository. It can also update the repository when it notices new docker images"
+"Dependabot",adopt,"Tools",true,"We should use <a href='https://github.com/dependabot'>Dependabot</a> for automating creation of PRs to update dependencies."
+"Renovate",hold,"Tools",true,"Prefer Dependabot instead"
 "Redgate Platform",adopt,"Platforms",true,"All new applications should be built on the Redgate Platform."
 "Kubernetes",adopt,"Platforms",true,"<a href='https://kubernetes.io/'>K8S</a> is the undeniable winner of orchestration tools."
 "SQL Server as backing store",adopt,"Platforms",true,"When a product needs to store more complex data than it can fit in a flat file, we ask the customer for a SQL DB."


### PR DESCRIPTION
I noticed that we seem to be using a mix of Dependabot and Renovate for automating dependency upgrade PRs in our repos. Should we consolidate on one, and if so which?

Currently I am leaning towards Dependabot because its fully integrated with Github where as Renovate is a third-party tool. There may however be good reason why Renovate is better than Dependabot so please do discuss :)

- [x] Are you happy for the content of this change to be publicly visible?
- [x] Are all new or updated entries marked as `isNew` = `true`?
- [x] Does `radar.csv` render correctly when viewed on Github?
- [x] Does the updated [tech radar](https://radar.thoughtworks.com/?sheetId=https%3A%2F%2Fraw.githubusercontent.com%2Fred-gate%2FTech-Radar%2Fadd-dependabot%2Fradar.csv) display as you expect?
